### PR TITLE
Quarry/Forge fuel balances

### DIFF
--- a/Entities/Structures/Forge/Forge.as
+++ b/Entities/Structures/Forge/Forge.as
@@ -6,11 +6,11 @@
 #include "Zombie_TechnologyCommon.as"
 
 const string fuel_prop = "fuel_level";
-const int max_fuel = 500;
+const int max_fuel = 750;
 
-const string[] fuel_names = {"mat_coal", "mat_wood"};
-const string[] fuel_icons = {"mat_coal_icon", "mat_wood"};
-const int[] fuel_strength = { 3, 1 };
+const string[] fuel_names = {"mat_wood", "mat_coal"};
+const string[] fuel_icons = {"mat_wood", "mat_coal_icon"};
+const int[] fuel_strength = { 1, 4 };
 
 void onInit(CBlob@ this)
 {

--- a/Entities/Structures/Forge/Forge.as
+++ b/Entities/Structures/Forge/Forge.as
@@ -6,7 +6,7 @@
 #include "Zombie_TechnologyCommon.as"
 
 const string fuel_prop = "fuel_level";
-const int max_fuel = 750;
+const int max_fuel = 1000;
 
 const string[] fuel_names = {"mat_wood", "mat_coal"};
 const string[] fuel_icons = {"mat_wood", "mat_coal_icon"};

--- a/Entities/Structures/Quarry/Quarry.as
+++ b/Entities/Structures/Quarry/Quarry.as
@@ -5,9 +5,9 @@
 #include "Zombie_Translation.as"
 #include "Zombie_TechnologyCommon.as"
 
-const string[] fuel_names = {"mat_coal", "mat_wood"};
-const string[] fuel_icons = {"mat_coal_icon", "mat_wood"};
-const int[] fuel_strength = { 3, 1 };
+const string[] fuel_names = {"mat_wood", "mat_coal"};
+const string[] fuel_icons = {"mat_wood", "mat_coal_icon"};
+const int[] fuel_strength = { 1, 4 };
 
 //balance
 const int input = 100;					// input cost in fuel
@@ -17,9 +17,9 @@ const int conversion_frequency = 30;	// how often to convert, in seconds
 const int min_input = Maths::Ceil(input / initial_output);
 
 //fuel levels for animation
-const int max_fuel = 500;
-const int mid_fuel = 300;
-const int low_fuel = 150;
+const int max_fuel = 1000;
+const int mid_fuel = 600;
+const int low_fuel = 250;
 
 //property names
 const string fuel_prop = "fuel_level";


### PR DESCRIPTION
Increased max amount of fuel for both forge and quarry for conveniency sake
- Max fuel for quarry 500 -> 1000
- Max fuel for forge 500 -> 1000
Also made fuel of coal be worth 4 instead of 3 because to make coal purely wood, it costs 35 wood to make 10 coal (25w for cost + 10w for time it takes to make coal) Since no one really uses coal was fuel also made it check for wood first before coal (since I dont wanna waste my coal for fuel) I think fuel could be worth 5, but we'll see how it goes in gameplay