### PR TITLE
Make Grains Stackable

### DIFF
--- a/Entities/Items/Food/Eatable.as
+++ b/Entities/Items/Food/Eatable.as
@@ -11,6 +11,7 @@ void onInit(CBlob@ this)
 	this.addCommandID("heal command server");
 
 	this.Tag("pushedByDoor");
+	if (this.getName() == "grain") this.maxQuantity = 5;
 }
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream@ params)

--- a/Entities/Structures/Forge/Forge.as
+++ b/Entities/Structures/Forge/Forge.as
@@ -6,7 +6,7 @@
 #include "Zombie_TechnologyCommon.as"
 
 const string fuel_prop = "fuel_level";
-const int max_fuel = 750;
+const int max_fuel = 1000;
 
 const string[] fuel_names = {"mat_wood", "mat_coal"};
 const string[] fuel_icons = {"mat_wood", "mat_coal_icon"};

--- a/Entities/Structures/Quarry/Quarry.as
+++ b/Entities/Structures/Quarry/Quarry.as
@@ -208,7 +208,7 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 			blob.server_SetQuantity(quantity - amountToStore);
 			if (amountToStore >= quantity) blob.server_Die();
 
-			this.add_s16(fuel_prop, amountToStore * fuel_strength[1]);
+			this.add_s16(fuel_prop, amountToStore * fuel_strength[0]);
 			this.Sync(fuel_prop, true);
 		}
 	}

--- a/Entities/Structures/Windmill/WindMill.as
+++ b/Entities/Structures/Windmill/WindMill.as
@@ -73,7 +73,9 @@ void convertToFlour(CBlob@ this, CBlob@ grain)
 		const u16 quantity = (10 + XORRandom(7)) * getMillingPercent();
 		flour.server_SetQuantity(quantity);
 		
-		grain.server_Die();
+		const int grainQuantity = grain.getQuantity() - 1; // int in case its quantity was 0 at the start
+		if (grainQuantity < 1) grain.server_Die();
+		else grain.server_SetQuantity(grainQuantity);
 		
 		//if (!this.server_PutInInventory(flour))
 			flour.setPosition(this.getPosition() + Vec2f(4, 24));


### PR DESCRIPTION
Now grains stackable to 5, shouldn't clog up inventories for no reason anymore lmao. Also no need to change eating system since you cant eat grain and only windmill uses the grain